### PR TITLE
fix: allow multiple uses of injector module in a single python process

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -3,6 +3,7 @@ cls
 composable
 configurationerror
 iterable
+lineno
 mypy
 pragma
 py

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,40 +11,40 @@ jobs:
     env:
       PACKAGE_NAME: "banshee"
     steps:
-    - name: release please
-      uses: google-github-actions/release-please-action@v3
-      id: release
-      with:
-        release-type: python
-        package-name: ${{ env.PACKAGE_NAME }}
+      - name: release please
+        uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          release-type: python
+          package-name: ${{ env.PACKAGE_NAME }}
 
-    - name: fetch code
-      uses: actions/checkout@v4
-      if: ${{ steps.release.outputs.release_created }}
+      - name: fetch code
+        uses: actions/checkout@v4
+        if: ${{ steps.release.outputs.release_created }}
 
-    - name: set python version
-      if: ${{ steps.release.outputs.release_created }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.10"
+      - name: set python version
+        if: ${{ steps.release.outputs.release_created }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
 
-    - name: install dependencies
-      uses: artisanal-actions/poetry-install@v1
-      if: ${{ steps.release.outputs.release_created }}
+      - name: install dependencies
+        uses: artisanal-actions/poetry-install@v1
+        if: ${{ steps.release.outputs.release_created }}
 
-    - name: build release
-      if: ${{ steps.release.outputs.release_created }}
-      run: poetry build
-      
-    - name: upload assets
-      uses: softprops/action-gh-release@v1
-      if: ${{ steps.release.outputs.release_created }}
-      with:
-        tag_name: ${{ steps.release.outputs.tag_name }}
-        files: dist/*
+      - name: build release
+        if: ${{ steps.release.outputs.release_created }}
+        run: poetry build
 
-    - name: publish release
-      if: ${{ steps.release.outputs.release_created }}
-      run: poetry publish
-      env:
-        POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_AUTH_TOKEN }}
+      - name: upload assets
+        uses: softprops/action-gh-release@v1
+        if: ${{ steps.release.outputs.release_created }}
+        with:
+          tag_name: ${{ steps.release.outputs.tag_name }}
+          files: dist/*
+
+      - name: publish release
+        if: ${{ steps.release.outputs.release_created }}
+        run: poetry publish
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_AUTH_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,36 +3,38 @@ name: tests
 on:
   push:
     paths-ignore:
-      - 'docs/**'
+      - "docs/**"
     branches:
       - main
   pull_request:
     paths-ignore:
-      - 'docs/**'
+      - "docs/**"
     branches:
-      - '**'
+      - "**"
 
 jobs:
   tests:
     runs-on: ubuntu-latest
 
     steps:
-    - name: fetch code
-      uses: actions/checkout@v4
+      - name: fetch code
+        uses: actions/checkout@v4
 
-    - name: install en-gb dictionary
-      run: sudo apt-get install -y hunspell-en-gb
+      - name: install en-gb dictionary
+        run: sudo apt-get install -y hunspell-en-gb
 
-    - name: set python version
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.10"
+      - name: set python version
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
 
-    - name: install dependencies
-      uses: artisanal-actions/poetry-install@v1
+      - name: install dependencies
+        uses: artisanal-actions/poetry-install@v1
+        with:
+          extras: injector
 
-    - name: Install pytest plugin
-      run: poetry run pip install pytest-github-actions-annotate-failures
+      - name: Install pytest plugin
+        run: poetry run pip install pytest-github-actions-annotate-failures
 
-    - name: run tests
-      run: make ci
+      - name: run tests
+        run: make ci

--- a/src/banshee/extra/injector.py
+++ b/src/banshee/extra/injector.py
@@ -92,11 +92,6 @@ class BansheeModule(injector.Module):
         self.registry = registry
 
     def configure(self, binder: injector.Binder) -> None:
-        binder.bind(injector.inject(banshee.IdentityMiddleware))
-        binder.bind(injector.inject(banshee.CausationMiddleware))
-        binder.bind(injector.inject(banshee.HandleAfterMiddleware))
-        binder.bind(injector.inject(banshee.DispatchMiddleware))
-
         if self.registry:
             # https://github.com/python/mypy/issues/4717
             binder.bind(
@@ -109,15 +104,11 @@ class BansheeModule(injector.Module):
     @injector.singleton
     @injector.provider
     def _provide_factory(self, container: injector.Injector) -> banshee.HandlerFactory:
-        # pylint: disable=no-self-use
-
         return InjectorHandlerFactory(container)
 
     @injector.singleton
     @injector.provider
     def _provide_message_bus(self, container: injector.Injector) -> banshee.Bus:
-        # pylint: disable=no-self-use
-
         return (
             banshee.Builder()
             .with_middleware(container.get(banshee.IdentityMiddleware))

--- a/src/banshee/message.py
+++ b/src/banshee/message.py
@@ -145,7 +145,7 @@ def message_for(
     :returns: a message for the request and context objects
     """
     if not isinstance(request, Message):
-        return Message(request, contexts=tuple(contexts) if contexts else tuple())
+        return Message(request, contexts=tuple(contexts) if contexts else ())
 
     if not contexts:
         return request
@@ -213,6 +213,7 @@ class MiddlewareChain(HandleMessage):
         self.iterator = iterator
 
     async def _final(self, message: Message[T], handle: HandleMessage) -> Message[T]:
+        # pylint: disable=unused-argument
         return message
 
     async def __call__(self, message: Message[T]) -> Message[T]:

--- a/tests/unit/test_injector_banshee_module.py
+++ b/tests/unit/test_injector_banshee_module.py
@@ -1,0 +1,33 @@
+"""
+Tests for :class:`banshee.extra.injector.BansheeModule`
+"""
+
+import injector
+
+import banshee
+import banshee.extra.injector
+
+
+def test_it_should_build_bus_instance() -> None:
+    """
+    it should build bus instance.
+    """
+    registry = banshee.Registry()
+    container = injector.Injector(banshee.extra.injector.BansheeModule(registry))
+    bus = container.get(banshee.Bus)  # type: ignore
+
+    assert isinstance(bus, banshee.Bus)
+
+
+def test_it_should_allow_multiple_uses() -> None:
+    """
+    it should allow multiple uses.
+    """
+    registry = banshee.Registry()
+    container = injector.Injector(banshee.extra.injector.BansheeModule(registry))
+    bus1 = container.get(banshee.Bus)  # type: ignore
+
+    container = injector.Injector(banshee.extra.injector.BansheeModule(registry))
+    bus2 = container.get(banshee.Bus)  # type: ignore
+
+    assert bus1 is not bus2


### PR DESCRIPTION
Fixes #83 

## Description

Removes superfluous calls to `binder.bind()` that was causing a crash when the module was used a second time.

## Motivation and Context

Fixes an unforeseen error case with the injector integration.

## How Has This Been Tested?

Additional unit tests were added and manual poking.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

